### PR TITLE
Update tfhelper.py

### DIFF
--- a/cymetric/models/tfhelper.py
+++ b/cymetric/models/tfhelper.py
@@ -61,6 +61,8 @@ def train_model(fsmodel, data, optimizer=None, epochs=50, batch_sizes=[64, 10000
         sample_weights = None
     if optimizer is None:
         optimizer = tf.keras.optimizers.Adam()
+    # Compile once at start of training to avoid resetting optimizer
+    fsmodel.compile(custom_metrics=custom_metrics, optimizer=optimizer)
     for epoch in range(epochs):
         batch_size = batch_sizes[0]
         fsmodel.learn_kaehler = learn_kaehler
@@ -68,7 +70,6 @@ def train_model(fsmodel, data, optimizer=None, epochs=50, batch_sizes=[64, 10000
         fsmodel.learn_ricci = learn_ricci
         fsmodel.learn_ricci_val = learn_ricci_val
         fsmodel.learn_volk = tf.cast(False, dtype=tf.bool)
-        fsmodel.compile(custom_metrics=custom_metrics, optimizer=optimizer)
         if verbose > 0:
             print("\nEpoch {:2d}/{:d}".format(epoch + 1, epochs))
         history = fsmodel.fit(
@@ -87,7 +88,6 @@ def train_model(fsmodel, data, optimizer=None, epochs=50, batch_sizes=[64, 10000
         fsmodel.learn_ricci = tf.cast(False, dtype=tf.bool)
         fsmodel.learn_ricci_val = tf.cast(False, dtype=tf.bool)
         fsmodel.learn_volk = tf.cast(True, dtype=tf.bool)
-        fsmodel.compile(custom_metrics=custom_metrics, optimizer=optimizer)
         history = fsmodel.fit(
             data['X_train'], data['y_train'],
             epochs=1, batch_size=batch_size, verbose=verbose,


### PR DESCRIPTION
Avoid recompiling after each epoch which resets the optimizer and loses gradients.

Since the Adam optimizer uses momentum to adjust gradient updates, each time we call model.compile it resets the optimizer and loses all the momentum information. This leads to suboptimal training.

When this updated training loop is used on the basic Fermat Quintic example in the tutorial notebooks, the result is much smoother training, as well as a lower value for the sigma and transition loss after 50 training epochs.

Updated code:
![Unknown](https://github.com/pythoncymetric/cymetric/assets/67048024/7d6c008e-7c69-4134-909f-21bba9885a82)

Old code (taken from cymetric/tree/main/notebooks/2.TensorFlow_models.ipynb):
<img width="694" alt="Screen Shot 2024-04-06 at 4 20 52 PM" src="https://github.com/pythoncymetric/cymetric/assets/67048024/a978eda7-87f5-4fe9-a13d-45936bf9217f">

